### PR TITLE
Record spans for more nodes in the AST

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -8,8 +8,8 @@ pub enum Stmt {
   SoundChange {
     source: Spanned<Source>,
     target: Spanned<Target>,
-    environment: Option<Environment>,
-    description: Option<String>,
+    environment: Option<Spanned<Environment>>,
+    description: Option<Spanned<String>>,
   },
   Import {
     path: Vec<Spanned<String>>,
@@ -17,21 +17,21 @@ pub enum Stmt {
     names: Vec<Spanned<String>>,
   },
   Language {
-    id: String,
-    parent: Option<String>,
-    name: Option<String>,
+    id: Spanned<String>,
+    parent: Option<Spanned<String>>,
+    name: Option<Spanned<String>>,
   },
   Word {
-    gloss: String,
-    pronunciation: Vec<String>,
+    gloss: Spanned<String>,
+    pronunciation: Spanned<Vec<String>>,
     definitions: Vec<Definition>,
   },
   Class {
-    label: String,
+    label: Spanned<String>,
     class: Class,
   },
   Trait {
-    label: String,
+    label: Spanned<String>,
     members: Vec<TraitMember>,
   },
   Milestone {
@@ -91,15 +91,15 @@ pub enum EnvElement {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Definition {
-  pub pos: Option<String>,
-  pub definition: String,
+  pub pos: Option<Spanned<String>>,
+  pub definition: Spanned<String>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Class {
   Full {
-    encodes: Vec<String>,
-    annotates: Vec<String>,
+    encodes: Vec<Spanned<String>>,
+    annotates: Vec<Spanned<String>>,
     phonemes: Vec<PhonemeDef>,
   },
   Category(Category),
@@ -108,14 +108,14 @@ pub enum Class {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PhonemeDef {
-  pub label: String,
-  pub traits: Vec<String>,
+  pub label: Spanned<String>,
+  pub traits: Vec<Spanned<String>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct TraitMember {
-  pub labels: Vec<String>,
-  pub notation: Option<String>,
+  pub labels: Vec<Spanned<String>>,
+  pub notation: Option<Spanned<String>>,
   pub default: bool,
 }
 

--- a/src/parser/class_definition.rs
+++ b/src/parser/class_definition.rs
@@ -1,10 +1,15 @@
 use chumsky::{prelude::*, text::{ident, whitespace}};
-use crate::parser::common::*;
+use crate::{parser::common::*, ast::Spanned};
 use crate::ast::{
   Stmt,
   PhonemeDef,
   Class,
 };
+
+fn label() -> impl Parser<char, Spanned<String>, Error = Simple<char>> {
+  class()
+    .map_with_span(|c, span| (span, c.to_string()))
+}
 
 pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
   let start = just("class")
@@ -14,6 +19,7 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .padded()
     .ignore_then(
       ident()
+        .map_with_span(|id, span| (span, id))
         .separated_by(whitespace())
         .allow_leading()
         .allow_trailing()
@@ -24,6 +30,7 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .padded()
     .ignore_then(
       ident()
+        .map_with_span(|id, span| (span, id))
         .separated_by(whitespace())
         .allow_leading()
         .allow_trailing()
@@ -36,9 +43,11 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     });
 
   let phoneme_definition = word_chars()
+    .map_with_span(|phoneme, span| (span, phoneme))
     .then_ignore(just("=").padded())
     .then(
       ident()
+        .map_with_span(|traits, span| (span, traits))
         .separated_by(inline_whitespace())
         .allow_leading()
         .allow_trailing()
@@ -53,14 +62,14 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .delimited_by(just("{").padded(), just("}"));
 
   let full = start
-    .ignore_then(class().map(|c| c.to_string()))
+    .ignore_then(label())
     .then(encodes)
     .then(annotates)
     .then(body)
     .map(|(((label, encodes), annotates), phonemes)| (label, Class::Full { encodes, annotates, phonemes }));
 
   let list = start
-    .ignore_then(class().map(|c| c.to_string()))
+    .ignore_then(label())
     .then_ignore(just("=").padded())
     .then(
       word_chars()
@@ -73,10 +82,10 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .map(|(label, ps)| (label, Class::List(ps)));
   
   let category = start
-  .ignore_then(class().map(|c| c.to_string()))
-  .then_ignore(just("=").padded())
-  .then(category())
-  .map(|(label, c)| (label, Class::Category(c)));
+    .ignore_then(label())
+    .then_ignore(just("=").padded())
+    .then(category())
+    .map(|(label, c)| (label, Class::Category(c)));
   
   choice([
     full.boxed(),
@@ -98,7 +107,7 @@ use super::*;
     assert_eq!(
       parser().parse("class C = { a, b, c }"),
       Ok(Stmt::Class {
-        label: "C".into(),
+        label: (6..7, "C".into()),
         class: Class::List(vec!["a".into(), "b".into(), "c".into()])
       })
     )
@@ -116,15 +125,15 @@ use super::*;
         }"
       ),
       Ok(Stmt::Class {
-        label: "C".into(),
+        label: (6..7, "C".into()),
         class: Class::Full {
-          encodes: vec!["place".into(), "manner".into()],
+          encodes: vec![(17..22, "place".into()), (23..29, "manner".into())],
           annotates: vec![],
           phonemes: vec![
-            PhonemeDef { label: "p".into(), traits: vec!["bilabial".into(), "plosive".into()] },
-            PhonemeDef { label: "t".into(), traits: vec!["alveolar".into(), "plosive".into()] },
-            PhonemeDef { label: "k".into(), traits: vec!["velar".into(), "plosive".into()] },
-            PhonemeDef { label: "t͡s".into(), traits: vec!["alveolar".into(), "affricate".into()] },
+            PhonemeDef { label: (43..44, "p".into()), traits: vec![(47..55, "bilabial".into()), (56..63, "plosive".into())] },
+            PhonemeDef { label: (75..76, "t".into()), traits: vec![(79..87, "alveolar".into()), (88..95, "plosive".into())] },
+            PhonemeDef { label: (107..108, "k".into()), traits: vec![(111..116, "velar".into()), (117..124, "plosive".into())] },
+            PhonemeDef { label: (136..139, "t͡s".into()), traits: vec![(142..150, "alveolar".into()), (151..160, "affricate".into())] },
           ]
         }
       })
@@ -136,7 +145,7 @@ use super::*;
     assert_eq!(
       parser().parse("class F = [C+fricative]"),
       Ok(Stmt::Class {
-        label: "F".into(),
+        label: (6..7, "F".into()),
         class: Class::Category(Category { base_class: Some('C'), features: vec![Feature::Positive("fricative".into())] })
       })
     )

--- a/src/parser/lang_definition.rs
+++ b/src/parser/lang_definition.rs
@@ -4,17 +4,25 @@ use crate::ast::Stmt;
 pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
   let start = just("lang").padded();
 
-  let id = ident();
+  let id = ident()
+    .map_with_span(|id, span| (span, id));
 
   let parent = just("<")
     .padded()
-    .ignore_then(ident())
+    .ignore_then(
+      ident()
+        .map_with_span(|p, span| (span, p))
+    )
     .or_not();
 
   let name = just(":")
     .padded()
-    .ignore_then(filter(|c: &char| c.is_alphanumeric() || c.is_inline_whitespace() || "-()".contains(*c)).repeated().at_least(1))
-    .map(|cs| cs.iter().collect())
+    .ignore_then(
+      filter(|c: &char| c.is_alphanumeric() || c.is_inline_whitespace() || "-()".contains(*c))
+        .repeated()
+        .at_least(1)
+        .map_with_span(|cs, span| (span, cs.iter().collect()))
+    )
     .or_not();
 
   start
@@ -33,7 +41,7 @@ mod test {
     let src = "lang PA";
     assert_eq!(
       parser().parse(src.to_string()),
-      Ok(Stmt::Language { id: "PA".to_string(), parent: None, name: None })
+      Ok(Stmt::Language { id: (5..7, "PA".to_string()), parent: None, name: None })
     )
   }
 
@@ -42,7 +50,7 @@ mod test {
     let src = "lang OA < PA";
     assert_eq!(
       parser().parse(src.to_string()),
-      Ok(Stmt::Language { id: "OA".to_string(), parent: Some("PA".to_string()), name: None })
+      Ok(Stmt::Language { id: (5..7, "OA".to_string()), parent: Some((10..12, "PA".to_string())), name: None })
     )
   }
 
@@ -51,7 +59,7 @@ mod test {
     let src = "lang PA: Proto-A";
     assert_eq!(
       parser().parse(src.to_string()),
-      Ok(Stmt::Language { id: "PA".to_string(), parent: None, name: Some("Proto-A".to_string()) })
+      Ok(Stmt::Language { id: (5..7, "PA".to_string()), parent: None, name: Some((9..16, "Proto-A".to_string())) })
     )
   }
 
@@ -60,7 +68,7 @@ mod test {
     let src = "lang OA < PA: Old A";
     assert_eq!(
       parser().parse(src.to_string()),
-      Ok(Stmt::Language { id: "OA".to_string(), parent: Some("PA".to_string()), name: Some("Old A".to_string()) })
+      Ok(Stmt::Language { id: (5..7, "OA".to_string()), parent: Some((10..12, "PA".to_string())), name: Some((14..19, "Old A".to_string())) })
     )
   }
 }

--- a/src/parser/sound_change.rs
+++ b/src/parser/sound_change.rs
@@ -65,11 +65,11 @@ fn env_pattern() -> impl Parser<char, EnvPattern, Error = Simple<char>> {
     .repeated().at_least(1)
 }
 
-fn environment() -> impl Parser<char, Environment, Error = Simple<char>> {
+fn environment() -> impl Parser<char, Spanned<Environment>, Error = Simple<char>> {
   env_pattern().or_not()
     .then_ignore(just("_"))
     .then(env_pattern().or_not())
-    .map(|(before, after)| Environment { before, after })
+    .map_with_span(|(before, after), span| (span, Environment { before, after }))
 }
 
 pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
@@ -91,7 +91,10 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
   let description =
     just(":")
     .padded()
-    .ignore_then(description())
+    .ignore_then(
+      description()
+        .map_with_span(|desc, span| (span, desc))
+    )
     .or_not();
 
   start
@@ -137,7 +140,7 @@ mod test {
         Stmt::SoundChange {
           source: (2..3, Source::Pattern(vec![Segment::Phonemes("k".into())])),
           target: (6..7, Target::Pattern(vec![Segment::Phonemes("c".into())])),
-          environment: Some(Environment {
+          environment: Some((10..20, Environment {
             before: None,
             after: Some(vec![
               EnvElement::Segment(Segment::Category(Category {
@@ -145,7 +148,7 @@ mod test {
                 features: vec![Feature::Positive("close".to_string())]
               }))
             ])
-          }),
+          })),
           description: None,
         }
       )
@@ -161,11 +164,11 @@ mod test {
         Stmt::SoundChange {
           source: (2..3, Source::Pattern(vec![Segment::Phonemes("k".into())])),
           target: (6..7, Target::Pattern(vec![Segment::Phonemes("c".into())])),
-          environment: Some(Environment {
+          environment: Some((10..13, Environment {
             before: Some(vec![EnvElement::WordBoundary]),
             after: Some(vec![EnvElement::Segment(Segment::Phonemes("i".into()))])
-          }),
-          description: Some("Word-initial k lenites to c before i".to_string()),
+          })),
+          description: Some((16..52, "Word-initial k lenites to c before i".to_string())),
         }
       )
     )

--- a/src/parser/trait_definition.rs
+++ b/src/parser/trait_definition.rs
@@ -18,10 +18,12 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
 
   let notation = just("=")
     .padded()
-    .ignore_then(sequence())
-    .then_ignore(just("_"))
-    .then(sequence())
-    .map(|(before, after)| before + "_" + &after)
+    .ignore_then(
+      sequence()
+        .then_ignore(just("_"))
+        .then(sequence())
+        .map_with_span(|(before, after), span| (span, before + "_" + &after))
+    )
     .or_not();
 
   let member = just("default")
@@ -30,6 +32,7 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .map(|d| d.is_some())
     .then(
       ident()
+        .map_with_span(|id, span| (span, id))
         .separated_by(just("|").padded())
         .at_least(1)
     )
@@ -44,7 +47,7 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .delimited_by(just("{").padded(), just("}"));
 
   start
-    .ignore_then(ident())
+    .ignore_then(ident().map_with_span(|id, span| (span, id)))
     .then(body)
     .map(|(label, members)| Stmt::Trait { label, members })
 }
@@ -66,11 +69,11 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Trait {
-          label: "Place".into(),
+          label: (13..18, "Place".into()),
           members: vec![
-            TraitMember { labels: vec!["labial".into()], notation: None, default: false },
-            TraitMember { labels: vec!["alveolar".into()], notation: None, default: false },
-            TraitMember { labels: vec!["velar".into()], notation: None, default: false },
+            TraitMember { labels: vec![(29..35, "labial".into())], notation: None, default: false },
+            TraitMember { labels: vec![(45..53, "alveolar".into())], notation: None, default: false },
+            TraitMember { labels: vec![(63..68, "velar".into())], notation: None, default: false },
           ],
         },
       )
@@ -89,10 +92,10 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Trait {
-          label: "Stress".into(),
+          label: (13..19, "Stress".into()),
           members: vec![
-            TraitMember { labels: vec!["primary".into()], notation: Some("ˈ_".into()), default: false },
-            TraitMember { labels: vec!["secondary".into()], notation: Some("ˌ_".into()), default: false },
+            TraitMember { labels: vec![(30..37, "primary".into())], notation: Some((40..42, "ˈ_".into())), default: false },
+            TraitMember { labels: vec![(52..61, "secondary".into())], notation: Some((64..66, "ˌ_".into())), default: false },
           ],
         },
       )
@@ -112,11 +115,11 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Trait {
-          label: "Length".into(),
+          label: (13..19, "Length".into()),
           members: vec![
-            TraitMember { labels: vec!["short".into()], notation: None, default: true },
-            TraitMember { labels: vec!["long".into()], notation: Some("_:".into()), default: false },
-            TraitMember { labels: vec!["overlong".into()], notation: Some("_::".into()), default: false },
+            TraitMember { labels: vec![(38..43, "short".into())], notation: None, default: true },
+            TraitMember { labels: vec![(53..57, "long".into())], notation: Some((60..62, "_:".into())), default: false },
+            TraitMember { labels: vec![(72..80, "overlong".into())], notation: Some((83..86, "_::".into())), default: false },
           ],
         },
       )

--- a/src/parser/word_definition.rs
+++ b/src/parser/word_definition.rs
@@ -8,11 +8,15 @@ use crate::ast::{
 
 fn definition() -> impl Parser<char, Definition, Error = Simple<char>> {
   ident()
+    .map_with_span(|pos, span| (span, pos))
     .then_ignore(just("."))
     .padded()
     .or_not()
-    .then(description())
-    .map(|(pos, definition)| Definition { pos, definition })
+    .then(
+      description()
+        .map_with_span(|def, span| (span, def))
+    )
+    .map(|(pos, definition)|  Definition { pos, definition })
 }
 
 fn definition_block() -> impl Parser<char, Vec<Definition>, Error = Simple<char>> {
@@ -27,12 +31,14 @@ fn definition_block() -> impl Parser<char, Vec<Definition>, Error = Simple<char>
 pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
   let start = just("-").padded();
 
-  let gloss = ident();
+  let gloss = ident()
+    .map_with_span(|g, span| (span, g));
 
   let pronunciation = syllable()
     .separated_by(just("."))
     .at_least(1)
     .delimited_by(just("/"), just("/"))
+    .map_with_span(|p, span| (span, p))
     .padded();
 
   let definitions = whitespace().ignore_then(
@@ -58,9 +64,14 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Word {
-          gloss: "water".to_string(),
-          pronunciation: vec!["'wa".to_string(), "ter".to_string()],
-          definitions: vec![Definition { pos: Some("noun".to_string()), definition: "the liquid state of H20".to_string() }],
+          gloss: (2..7, "water".to_string()),
+          pronunciation: (8..17, vec!["'wa".to_string(), "ter".to_string()]),
+          definitions: vec![
+            Definition {
+              pos: Some((18..22, "noun".to_string())),
+              definition: (24..47, "the liquid state of H20".to_string()),
+            }
+          ],
         },
       )
     )
@@ -77,9 +88,14 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Word {
-          gloss: "water".to_string(),
-          pronunciation: vec!["'wa".to_string(), "ter".to_string()],
-          definitions: vec![Definition { pos: Some("noun".to_string()), definition: "the liquid state of H20".to_string() }],
+          gloss: (9..14, "water".to_string()),
+          pronunciation: (15..24, vec!["'wa".to_string(), "ter".to_string()]),
+          definitions: vec![
+            Definition {
+              pos: Some((35..39, "noun".to_string())),
+              definition: (41..64, "the liquid state of H20".to_string()),
+            }
+          ],
         },
       )
     )
@@ -97,11 +113,17 @@ mod test {
       parser().parse(src.to_string()),
       Ok(
         Stmt::Word {
-          gloss: "water".to_string(),
-          pronunciation: vec!["'wa".to_string(), "ter".to_string()],
+          gloss: (9..14, "water".to_string()),
+          pronunciation: (15..24, vec!["'wa".to_string(), "ter".to_string()]),
           definitions: vec![
-            Definition { pos: Some("noun".to_string()), definition: "the liquid state of H20".to_string() },
-            Definition { pos: Some("verb".to_string()), definition: "to pour water over a plant or area of land".to_string() },
+            Definition {
+              pos: Some((35..39, "noun".to_string())),
+              definition: (41..64, "the liquid state of H20".to_string()),
+            },
+            Definition {
+              pos: Some((73..77, "verb".to_string())),
+              definition: (79..121, "to pour water over a plant or area of land".to_string()),
+            },
           ],
         },
       )


### PR DESCRIPTION
Annotate AST nodes with their spans (locations in source) for better error reporting, hints, etc. in future.