### PR TITLE
Differentiate `series` definitions & `class` definitions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -28,7 +28,13 @@ pub enum Stmt {
   },
   Class {
     label: Spanned<String>,
-    class: Class,
+    encodes: Vec<Spanned<String>>,
+    annotates: Vec<Spanned<String>>,
+    phonemes: Vec<PhonemeDef>,
+  },
+  Series {
+    label: Spanned<String>,
+    series: Spanned<Series>,
   },
   Trait {
     label: Spanned<String>,
@@ -48,7 +54,7 @@ pub enum Source {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Target {
-  Modification(Vec<Feature>),
+  Modification(Vec<Spanned<Feature>>),
   Pattern(Pattern),
   Empty,
 }
@@ -69,8 +75,8 @@ pub enum Segment {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Category {
-  pub base_class: Option<char>,
-  pub features: Vec<Feature>,
+  pub base_class: Option<Spanned<char>>,
+  pub features: Vec<Spanned<Feature>>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -88,7 +94,6 @@ pub enum EnvElement {
   WordBoundary,
 }
 
-
 #[derive(Debug, Clone, PartialEq)]
 pub struct Definition {
   pub pos: Option<Spanned<String>>,
@@ -96,14 +101,9 @@ pub struct Definition {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub enum Class {
-  Full {
-    encodes: Vec<Spanned<String>>,
-    annotates: Vec<Spanned<String>>,
-    phonemes: Vec<PhonemeDef>,
-  },
+pub enum Series {
   Category(Category),
-  List(Vec<String>),
+  List(Vec<Spanned<String>>),
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,13 @@ mod test {
     assert!(
       _parse("
         import * from @core/ipa
+        
+        series F = { i, e, ε, æ }
+
+        class X encodes (Place Manner) {
+          ℂ = velar trill,
+          ℤ = labiodental lateral_fricative ,
+        }
 
         lang OEng : Old English
         lang OEng < AmEng : American English

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3,6 +3,7 @@ use chumsky::{prelude::*, text::newline};
 use crate::ast::{Stmt, Spanned};
 
 mod class_definition;
+mod series_definition;
 mod common;
 mod import;
 mod lang_definition;
@@ -19,6 +20,7 @@ fn stmt() -> impl Parser<char, Stmt, Error = Simple<char>> {
     word_definition::parser().boxed(),
     trait_definition::parser().boxed(),
     class_definition::parser().boxed(),
+    series_definition::parser().boxed(),
     milestone::parser().boxed(),
   ])
     .then_ignore(newline().repeated().at_least(1).ignored().or(end()))

--- a/src/parser/class_definition.rs
+++ b/src/parser/class_definition.rs
@@ -1,17 +1,14 @@
 use chumsky::{prelude::*, text::{ident, whitespace}};
-use crate::{parser::common::*, ast::Spanned};
+use crate::parser::common::*;
 use crate::ast::{
   Stmt,
   PhonemeDef,
-  Class,
 };
 
-fn label() -> impl Parser<char, Spanned<String>, Error = Simple<char>> {
-  class()
-    .map_with_span(|c, span| (span, c.to_string()))
-}
-
 pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
+  let label = class()
+    .map_with_span(|c, span| (span, c.to_string()));
+
   let start = just("class")
     .padded();
 
@@ -61,57 +58,17 @@ pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
     .then_ignore(whitespace())
     .delimited_by(just("{").padded(), just("}"));
 
-  let full = start
-    .ignore_then(label())
+  start
+    .ignore_then(label)
     .then(encodes)
     .then(annotates)
     .then(body)
-    .map(|(((label, encodes), annotates), phonemes)| (label, Class::Full { encodes, annotates, phonemes }));
-
-  let list = start
-    .ignore_then(label())
-    .then_ignore(just("=").padded())
-    .then(
-      word_chars()
-        .separated_by(just(",").padded())
-        .allow_trailing()
-        .at_least(1)
-        .then_ignore(whitespace())
-        .delimited_by(just("{").padded(), just("}"))
-    )
-    .map(|(label, ps)| (label, Class::List(ps)));
-  
-  let category = start
-    .ignore_then(label())
-    .then_ignore(just("=").padded())
-    .then(category())
-    .map(|(label, c)| (label, Class::Category(c)));
-  
-  choice([
-    full.boxed(),
-    list.boxed(),
-    category.boxed(),
-  ])
-    .map(|(label, class)| Stmt::Class { label, class })
-
+    .map(|(((label, encodes), annotates), phonemes)| Stmt::Class { label, encodes, annotates, phonemes })
 }
 
 #[cfg(test)]
 mod test {
-  use crate::ast::{Category, Feature};
-
-use super::*;
-
-  #[test]
-  fn it_parses_a_list_class_definition() {
-    assert_eq!(
-      parser().parse("class C = { a, b, c }"),
-      Ok(Stmt::Class {
-        label: (6..7, "C".into()),
-        class: Class::List(vec!["a".into(), "b".into(), "c".into()])
-      })
-    )
-  }
+  use super::*;
 
   #[test]
   fn it_parses_a_full_class_definition() {
@@ -126,27 +83,14 @@ use super::*;
       ),
       Ok(Stmt::Class {
         label: (6..7, "C".into()),
-        class: Class::Full {
-          encodes: vec![(17..22, "place".into()), (23..29, "manner".into())],
-          annotates: vec![],
-          phonemes: vec![
-            PhonemeDef { label: (43..44, "p".into()), traits: vec![(47..55, "bilabial".into()), (56..63, "plosive".into())] },
-            PhonemeDef { label: (75..76, "t".into()), traits: vec![(79..87, "alveolar".into()), (88..95, "plosive".into())] },
-            PhonemeDef { label: (107..108, "k".into()), traits: vec![(111..116, "velar".into()), (117..124, "plosive".into())] },
-            PhonemeDef { label: (136..139, "t͡s".into()), traits: vec![(142..150, "alveolar".into()), (151..160, "affricate".into())] },
-          ]
-        }
-      })
-    )
-  }
-
-  #[test]
-  fn it_parses_a_category_class_definition() {
-    assert_eq!(
-      parser().parse("class F = [C+fricative]"),
-      Ok(Stmt::Class {
-        label: (6..7, "F".into()),
-        class: Class::Category(Category { base_class: Some('C'), features: vec![Feature::Positive("fricative".into())] })
+        encodes: vec![(17..22, "place".into()), (23..29, "manner".into())],
+        annotates: vec![],
+        phonemes: vec![
+          PhonemeDef { label: (43..44, "p".into()), traits: vec![(47..55, "bilabial".into()), (56..63, "plosive".into())] },
+          PhonemeDef { label: (75..76, "t".into()), traits: vec![(79..87, "alveolar".into()), (88..95, "plosive".into())] },
+          PhonemeDef { label: (107..108, "k".into()), traits: vec![(111..116, "velar".into()), (117..124, "plosive".into())] },
+          PhonemeDef { label: (136..139, "t͡s".into()), traits: vec![(142..150, "alveolar".into()), (151..160, "affricate".into())] },
+        ]
       })
     )
   }

--- a/src/parser/common.rs
+++ b/src/parser/common.rs
@@ -53,8 +53,16 @@ pub fn feature() -> impl Parser<char, Feature, Error = Simple<char>> {
 }
 
 pub fn category() -> impl Parser<char, Category, Error = Simple<char>> {
-  class().padded().or_not()
-    .then(feature().repeated().at_least(1))
+  class()
+    .map_with_span(|class, span| (span, class))
+    .padded()
+    .or_not()
+    .then(
+      feature()
+        .map_with_span(|feat, span| (span, feat))
+        .repeated()
+        .at_least(1)
+    )
     .delimited_by(just("["), just("]"))
     .map(|(base_class, features)| Category { base_class, features })
 }

--- a/src/parser/series_definition.rs
+++ b/src/parser/series_definition.rs
@@ -1,0 +1,74 @@
+use chumsky::{prelude::*, text::whitespace};
+use crate::{parser::common::*, ast::{Spanned, Series}};
+use crate::ast::Stmt;
+
+fn label() -> impl Parser<char, Spanned<String>, Error = Simple<char>> {
+  class()
+    .map_with_span(|c, span| (span, c.to_string()))
+}
+
+pub fn parser() -> impl Parser<char, Stmt, Error = Simple<char>> {
+  let start = just("series")
+    .padded();
+
+  let list = 
+    word_chars()
+      .map_with_span(|phoneme, span| (span, phoneme))
+      .separated_by(just(",").padded())
+      .allow_trailing()
+      .at_least(1)
+      .then_ignore(whitespace())
+      .delimited_by(just("{").padded(), just("}"))
+      .map(|phonemes| Series::List(phonemes));
+  
+  let category = category()
+    .map(|cat| Series::Category(cat));
+
+  let body =
+    choice([
+      list.boxed(),
+      category.boxed(),
+    ]).map_with_span(|series, span| (span, series));
+
+  start
+    .ignore_then(label())
+    .then_ignore(just("=").padded())
+    .then(body)
+    .map(|(label, series)| Stmt::Series { label, series })
+}
+
+#[cfg(test)]
+mod test {
+  use crate::ast::{Category, Feature};
+
+  use super::*;
+
+  #[test]
+  fn it_parses_a_list_class_definition() {
+    assert_eq!(
+      parser().parse("series C = { a, b, c }"),
+      Ok(Stmt::Series {
+        label: (7..8, "C".into()),
+        series: (11..22, Series::List(vec![
+          (13..14, "a".into()),
+          (16..17, "b".into()),
+          (19..20, "c".into()),
+        ])),
+      })
+    )
+  }
+
+  #[test]
+  fn it_parses_a_category_class_definition() {
+    assert_eq!(
+      parser().parse("series F = [C+fricative]"),
+      Ok(Stmt::Series {
+        label: (7..8, "F".into()),
+        series: (11..24, Series::Category(Category {
+          base_class: Some((12..13, 'C')),
+          features: vec![(13..23, Feature::Positive("fricative".into()))]
+        })),
+      })
+    )
+  }
+}

--- a/src/parser/sound_change.rs
+++ b/src/parser/sound_change.rs
@@ -39,6 +39,7 @@ fn source() -> impl Parser<char, Spanned<Source>, Error = Simple<char>> {
 
 fn modification() -> impl Parser<char, Target, Error = Simple<char>> {
   feature()
+    .map_with_span(|feat, span| (span, feat))
     .repeated()
     .at_least(1)
     .delimited_by(just("["), just("]"))
@@ -144,8 +145,8 @@ mod test {
             before: None,
             after: Some(vec![
               EnvElement::Segment(Segment::Category(Category {
-                base_class: Some('V'),
-                features: vec![Feature::Positive("close".to_string())]
+                base_class: Some((12..13, 'V')),
+                features: vec![(13..19, Feature::Positive("close".to_string()))]
               }))
             ])
           })),
@@ -184,13 +185,18 @@ mod test {
           source: (
             2..19,
             Source::Pattern(vec![Segment::Category(Category {
-              base_class: Some('C'),
-              features: vec![Feature::Positive("stop".to_string()), Feature::Positive("alveolar".to_string())]
+              base_class: Some((3..4, 'C')),
+              features: vec![
+                (4..9, Feature::Positive("stop".to_string())),
+                (9..18, Feature::Positive("alveolar".to_string())),
+              ],
             })])
           ),
           target: (
             22..29,
-            Target::Modification(vec![Feature::Positive("flap".to_string())])
+            Target::Modification(vec![
+              (23..28, Feature::Positive("flap".to_string())),
+            ])
           ),
           environment: None,
           description: None,


### PR DESCRIPTION
This PR adds a `series` statement, which replaces previous "list" and "category" `class` types. The resulting new syntax and AST structure better reflects the semantic difference between these kinds of definitions, where a `series` encodes a selection of related phonemes from an existing `class`, rather than defining a set of new phonemes.

More AST nodes have been `Spanned` where relevant (e.g. category expressions, the `series`'s phoneme list itself, etc.)