### PR TITLE
Fix statement top-level spans

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,32 +55,34 @@ mod test {
 
   #[test]
   fn it_works() {
-    assert!(
-      _parse("
-        import * from @core/ipa
-        
-        series F = { i, e, ε, æ }
+    let res = _parse("
+      import * from @core/ipa
+      
+      series F = { i, e, ε, æ }
 
-        class X encodes (Place Manner) {
-          ℂ = velar trill,
-          ℤ = labiodental lateral_fricative ,
-        }
+      class X encodes (Place Manner) {
+        ℂ = velar trill,
+        ℤ = labiodental lateral_fricative ,
+      }
 
-        lang OEng : Old English
-        lang OEng < AmEng : American English
-        lang OEng < RP : Received Pronunciation
-        
-        @ 1000, OEng
-        
-        - water /ˈwæ.ter/ {
-          noun. liquid that forms the seas, lakes, rivers, and rain
-          verb. pour or sprinkle water over a plant or area
-        }
-        
-        @ 1940, AmEng
-        
-        $ [C+alveolar+stop] > [+flap] / V_V : Alveolar stops lenite to flaps intervocallically
-      ").is_ok()
-    )
+      lang OEng : Old English
+      lang OEng < AmEng : American English
+      lang OEng < RP : Received Pronunciation
+      
+      @ 1000, OEng
+      
+      - water /ˈwæ.ter/ {
+        noun. liquid that forms the seas, lakes, rivers, and rain
+        verb. pour or sprinkle water over a plant or area
+      }
+      
+      @ 1940, AmEng
+      
+      $ [C+alveolar+stop] > [+flap] / V_V : Alveolar stops lenite to flaps intervocallically
+    ");
+
+    println!("{:#?}", res);
+
+    assert!(res.is_ok())
   }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use chumsky::{prelude::*, text::newline};
+use chumsky::{prelude::*, text::{newline, whitespace}};
 
 use crate::ast::{Stmt, Spanned};
 
@@ -12,7 +12,7 @@ mod trait_definition;
 mod word_definition;
 mod milestone;
 
-fn stmt() -> impl Parser<char, Stmt, Error = Simple<char>> {
+fn stmt() -> impl Parser<char, Spanned<Stmt>, Error = Simple<char>> {
   choice([
     sound_change::parser().boxed(),
     import::parser().boxed(),
@@ -23,12 +23,13 @@ fn stmt() -> impl Parser<char, Stmt, Error = Simple<char>> {
     series_definition::parser().boxed(),
     milestone::parser().boxed(),
   ])
+    .map_with_span(|stmt, span| (span, stmt))
     .then_ignore(newline().repeated().at_least(1).ignored().or(end()))
+    .then_ignore(whitespace())
 }
 
 fn root() -> impl Parser<char, Vec<Spanned<Stmt>>, Error = Simple<char>> {
   stmt()
-    .map_with_span(|stmt, span| (span, stmt))
     .repeated()
     .padded()
     .then_ignore(end())


### PR DESCRIPTION
This PR ensures that the spans captured when matching statements do not encompass any trailing or leading whitespace, by moving the `map_with_span` before any whitespace is matched.